### PR TITLE
Fix correct use of WithTraceAll() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
 gormLogger := slogGorm.New(
     slogGorm.WithLogger(logger), // Optional, use slog.Default() by default
-    slogGorm.WithTraceAll(slog.Info), // trace all messages and define the default logging level
+    slogGorm.WithTraceAll(), // trace all messages 
+    slogGorm.SetLogLevel(DefaultLogType, slog.Level(32)), // Define the default logging level
 )
 ```
 


### PR DESCRIPTION
Refactored the documentation to accurately reflect the usage of the `WithTraceAll()` function. 


<pre><code>
gormLogger := slogGorm.New(
    slogGorm.WithLogger(logger), // Optional, use slog.Default() by default
    <del>slogGorm.WithTraceAll(slog.Info), // trace all messages and define the default logging level</del>
    slogGorm.WithTraceAll(), // trace all messages                                                                                                                                                                       
    slogGorm.SetLogLevel(DefaultLogType, slog.Level(32)), // Define the default logging level
)
</code></pre>