### PR TITLE
Feat: append gorm request context attributes to slog attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ customLogger := sloggorm.New(
 
 	slogGorm.WithErrorField("err"),     // instead of "error" (by default)
 
-	slogGorm.WithContextValue("key"),   // adds an slog.Attr if a value if found for this key in the Gorm's query context
+	slogGorm.WithContextValue("slogAttrName", "ctxKey"), // adds an slog.Attr if a value if found for this key in the Gorm's query context
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ customLogger := sloggorm.New(
 	slogGorm.WithSourceField("origin"), // instead of "file" (by default)
 
 	slogGorm.WithErrorField("err"),     // instead of "error" (by default)
+
+	slogGorm.WithContextValue("key"),   // adds an slog.Attr if a value if found for this key in the Gorm's query context
 )
 ```
 

--- a/logger.go
+++ b/logger.go
@@ -62,7 +62,7 @@ type logger struct {
 	traceAll                  bool
 	slowThreshold             time.Duration
 	logLevel                  map[LogType]slog.Level
-	contextKeys               []string
+	contextKeys               map[string]string
 
 	sourceField string
 	errorField  string
@@ -153,9 +153,9 @@ func (l logger) appendContextAttributes(ctx context.Context, args []any) []any {
 	if args == nil {
 		args = []any{}
 	}
-	for _, key := range l.contextKeys {
-		if value := ctx.Value(key); value != nil {
-			args = append(args, slog.Any(key, value))
+	for k, v := range l.contextKeys {
+		if value := ctx.Value(v); value != nil {
+			args = append(args, slog.Any(k, value))
 		}
 	}
 	return args

--- a/logger.go
+++ b/logger.go
@@ -62,6 +62,7 @@ type logger struct {
 	traceAll                  bool
 	slowThreshold             time.Duration
 	logLevel                  map[LogType]slog.Level
+	contextKeys               []string
 
 	sourceField string
 	errorField  string
@@ -75,17 +76,27 @@ func (l logger) LogMode(_ gormlogger.LogLevel) gormlogger.Interface {
 
 // Info logs info
 func (l logger) Info(ctx context.Context, msg string, args ...any) {
-	l.slogger.InfoContext(ctx, msg, args...)
+	l.log(l.slogger.InfoContext, ctx, msg, args...)
 }
 
 // Warn logs warn messages
 func (l logger) Warn(ctx context.Context, msg string, args ...any) {
-	l.slogger.WarnContext(ctx, msg, args...)
+	l.log(l.slogger.WarnContext, ctx, msg, args...)
 }
 
 // Error logs error messages
 func (l logger) Error(ctx context.Context, msg string, args ...any) {
-	l.slogger.ErrorContext(ctx, msg, args...)
+	l.log(l.slogger.ErrorContext, ctx, msg, args...)
+}
+
+// log adds context attributes and logs a message with the given slog function
+func (l logger) log(f func(ctx context.Context, msg string, args ...any), ctx context.Context, msg string, args ...any) {
+
+	// Append context attributes
+	args = l.appendContextAttributes(ctx, args)
+
+	// Call slog
+	f(ctx, msg, args...)
 }
 
 // Trace logs sql message
@@ -99,33 +110,53 @@ func (l logger) Trace(ctx context.Context, begin time.Time, fc func() (sql strin
 	case err != nil && (!errors.Is(err, gorm.ErrRecordNotFound) || !l.ignoreRecordNotFoundError):
 		sql, rows := fc()
 
-		l.slogger.Log(ctx, l.logLevel[ErrorLogType], err.Error(),
+		// Append context attributes
+		attributes := l.appendContextAttributes(ctx, []any{
 			slog.Any(l.errorField, err),
 			slog.String(QueryField, sql),
 			slog.Duration(DurationField, elapsed),
 			slog.Int64(RowsField, rows),
 			slog.String(l.sourceField, utils.FileWithLineNum()),
-		)
+		})
+
+		l.slogger.Log(ctx, l.logLevel[ErrorLogType], err.Error(), attributes...)
 
 	case l.slowThreshold != 0 && elapsed > l.slowThreshold:
 		sql, rows := fc()
 
-		l.slogger.Log(ctx, l.logLevel[SlowQueryLogType], fmt.Sprintf("slow sql query [%s >= %v]", elapsed, l.slowThreshold),
+		// Append context attributes
+		attributes := l.appendContextAttributes(ctx, []any{
 			slog.Bool(SlowQueryField, true),
 			slog.String(QueryField, sql),
 			slog.Duration(DurationField, elapsed),
 			slog.Int64(RowsField, rows),
 			slog.String(l.sourceField, utils.FileWithLineNum()),
-		)
+		})
+		l.slogger.Log(ctx, l.logLevel[SlowQueryLogType], fmt.Sprintf("slow sql query [%s >= %v]", elapsed, l.slowThreshold), attributes...)
 
 	case l.traceAll:
 		sql, rows := fc()
 
-		l.slogger.Log(ctx, l.logLevel[DefaultLogType], fmt.Sprintf("SQL query executed [%s]", elapsed),
+		// Append context attributes
+		attributes := l.appendContextAttributes(ctx, []any{
 			slog.String(QueryField, sql),
 			slog.Duration(DurationField, elapsed),
 			slog.Int64(RowsField, rows),
 			slog.String(l.sourceField, utils.FileWithLineNum()),
-		)
+		})
+
+		l.slogger.Log(ctx, l.logLevel[DefaultLogType], fmt.Sprintf("SQL query executed [%s]", elapsed), attributes...)
 	}
+}
+
+func (l logger) appendContextAttributes(ctx context.Context, args []any) []any {
+	if args == nil {
+		args = []any{}
+	}
+	for _, key := range l.contextKeys {
+		if value := ctx.Value(key); value != nil {
+			args = append(args, slog.Any(key, value))
+		}
+	}
+	return args
 }

--- a/options.go
+++ b/options.go
@@ -62,3 +62,13 @@ func WithIgnoreTrace() Option {
 		l.ignoreTrace = true
 	}
 }
+
+// WithContextValue adds a context value to the log
+func WithContextValue(contextKey string) Option {
+	return func(l *logger) {
+		if l.contextKeys == nil {
+			l.contextKeys = make([]string, 0)
+		}
+		l.contextKeys = append(l.contextKeys, contextKey)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -64,11 +64,11 @@ func WithIgnoreTrace() Option {
 }
 
 // WithContextValue adds a context value to the log
-func WithContextValue(contextKey string) Option {
+func WithContextValue(slogAttrName, contextKey string) Option {
 	return func(l *logger) {
 		if l.contextKeys == nil {
-			l.contextKeys = make([]string, 0)
+			l.contextKeys = make(map[string]string, 0)
 		}
-		l.contextKeys = append(l.contextKeys, contextKey)
+		l.contextKeys[slogAttrName] = contextKey
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -97,9 +97,10 @@ func TestWithSourceField(t *testing.T) {
 
 func TestWithContextValue(t *testing.T) {
 	actual := &logger{}
+	attrName := "attrName"
 	expected := "contextKey"
 
-	WithContextValue(expected)(actual)
+	WithContextValue(attrName, expected)(actual)
 
-	assert.Equal(t, []string{expected}, actual.contextKeys)
+	assert.Equal(t, map[string]string{attrName: expected}, actual.contextKeys)
 }

--- a/options_test.go
+++ b/options_test.go
@@ -94,3 +94,12 @@ func TestWithSourceField(t *testing.T) {
 
 	assert.Equal(t, expected, actual.sourceField)
 }
+
+func TestWithContextValue(t *testing.T) {
+	actual := &logger{}
+	expected := "contextKey"
+
+	WithContextValue(expected)(actual)
+
+	assert.Equal(t, []string{expected}, actual.contextKeys)
+}


### PR DESCRIPTION
This PR brings the ability to log context values with each Gorm log, which can be useful to log the SQL query with its corresponding trace or request ID.

It works the following way:

Instantiate the Gorm logger with option `WithContextValue(slogKey, contextKey string)`:
```go
// Build logger options
loggerOptions := []slogGorm.Option{
  slogGorm.WithContextValue("logging.googleapis.com/trace", "X-Cloud-Trace-Context"), // log the "X-Cloud-Trace-Context" context value in slog attribute "logging.googleapis.com/trace"
}
gormLogger := slogGorm.New(loggerOptions...)
```

When executing a query with Gorm, pass the context:
```go
ctx := context.WithValue(context.Background(), "X-Cloud-Trace-Context", "105445aa7843bc8bf206b12000100000/1;o=1"))
err := db.WithContext(ctx).First(&user).Error
```

And enjoy the following log line:
```json
{
  "time": "...",
  "level": "DEBUG",
  "msg": "...",
  "query": "SELECT * FROM users ORDER BY id LIMIT 1",
  "duration": 1,
  "rows": 1,
  "file": "...",
  "logging.googleapis.com/trace": "105445aa7843bc8bf206b12000100000/1;o=1"
}
```

In case the context key doesn't exist, the attribute is not added to the `slog` output.