### PR TITLE
Update go directive to 1.21 instead of 1.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/orandin/slog-gorm
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
Having `1.21.0` and using newer version, e.g. `1.21.4`, `go mod tidy` adds `toolchain go1.21.4` to my project. However, some people working on a project might be using `1.21.3` or `1.21.2` and so on. So let's not be so strict and set it to `1.21` without patch