### PR TITLE
fix: make extra log arguments as attributes

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -101,7 +101,7 @@ func (l logger) Error(ctx context.Context, format string, args ...any) {
 }
 
 // log adds context attributes and logs a message with the given slog level
-func (l logger) log(ctx context.Context, level slog.Level, format string, args ...any) {
+func (l logger) log(ctx context.Context, level slog.Level, msg string, args ...any) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -115,7 +115,9 @@ func (l logger) log(ctx context.Context, level slog.Level, format string, args .
 	// skip [runtime.Callers, this function, this function's caller]
 	runtime.Callers(3, pcs[:])
 	pc = pcs[0]
-	r := slog.NewRecord(time.Now(), level, fmt.Sprintf(format, args...), pc)
+	// r := slog.NewRecord(time.Now(), level, fmt.Sprintf(format, args...), pc)
+	r := slog.NewRecord(time.Now(), level, msg, pc)
+	r.Add(args...)
 	r.Add(l.appendContextAttributes(ctx, nil)...)
 
 	_ = l.sloggerHandler.Handle(ctx, r)


### PR DESCRIPTION
It seems gorm slog changed log format, making those attributes as part of the message. 
I dont' think this is good idea. 
For example, This is what slog-gorm v1.3.0 does(when formatted by [devslog](https://github.com/golang-cz/devslog) handler):

![截屏2024-03-21 11 39 55](https://github.com/orandin/slog-gorm/assets/6880156/8a288a75-34b2-48f1-b5b7-13b0ec714bda)

With a previous version of slog-gorm, it looks like: 
![截屏2024-03-21 11 40 23](https://github.com/orandin/slog-gorm/assets/6880156/31f633bd-f395-4c33-9d0b-35d9fb94a789)

Definitely the second one is better.

So I make this PR to recover previous behaviour.