### PR TITLE
chore: fix deprecated comment on WithLogger

### DIFF
--- a/options.go
+++ b/options.go
@@ -8,6 +8,7 @@ import (
 type Option func(l *logger)
 
 // WithLogger defines a custom logger to use
+//
 // Deprecated: Use WithHandler instead
 func WithLogger(log *slog.Logger) Option {
 	return func(l *logger) {


### PR DESCRIPTION
fix deprecated comment on WithLogger.

Deprecated comment should be the beginning of a paragraph. 

> To signal that an identifier should not be used, add a paragraph to its doc comment that begins with Deprecated: followed by some information about the deprecation, and a recommendation on what to use instead, if applicable. The paragraph does not have to be the last paragraph in the doc comment.

https://go.dev/wiki/Deprecated

I confirmed that staticcheck doesn't warn on the use of WithLogger method right now.
This change enable linters to find out the deprecated method usage.

