### PR TITLE
feat: allow adding attribute via a context function

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,15 @@ customLogger := sloggorm.New(
 
 	slogGorm.WithErrorField("err"),     // instead of "error" (by default)
 
-	slogGorm.WithContextValue("slogAttrName", "ctxKey"), // adds an slog.Attr if a value if found for this key in the Gorm's query context
+	slogGorm.WithContextValue("slogAttrName1", "ctxKey"), // adds an slog.Attr if a value is found for this key in the Gorm's query context
+
+	slogGorm.WithContextFunc("slogAttrName2", func(ctx context.Context) (slog.Value, bool) {
+        v, ok := ctx.Value(ctxKey1).(time.Duration)
+        if !ok {
+            return slog.Value{}, false
+        }
+        return slog.DurationValue(v), true
+    }), // adds an slog.Attr if the given function returns an slog.Value and true
 )
 ```
 

--- a/logger.go
+++ b/logger.go
@@ -68,6 +68,7 @@ type logger struct {
 	logLevel                  map[LogType]slog.Level
 	gormLevel                 gormlogger.LogLevel
 	contextKeys               map[string]string
+	contextFuncs              map[string]func(context.Context) (slog.Value, bool)
 
 	sourceField string
 	errorField  string
@@ -198,6 +199,11 @@ func (l logger) appendContextAttributes(ctx context.Context, args []any) []any {
 	}
 	for k, v := range l.contextKeys {
 		if value := ctx.Value(v); value != nil {
+			args = append(args, slog.Any(k, value))
+		}
+	}
+	for k, f := range l.contextFuncs {
+		if value, ok := f(ctx); ok {
 			args = append(args, slog.Any(k, value))
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package slogGorm
 
 import (
+	"context"
 	"log/slog"
 	"time"
 )
@@ -81,5 +82,18 @@ func WithContextValue(slogAttrName, contextKey string) Option {
 			l.contextKeys = make(map[string]string, 0)
 		}
 		l.contextKeys[slogAttrName] = contextKey
+	}
+}
+
+// WithContextFunc adds an attribute with the given name and slog.Value returned by the given
+// function if the function returns true. No attribute will be added if the function returns false.
+// Use this over WithContextValue if your context keys are not strings or only accessible via
+// functions.
+func WithContextFunc(slogAttrName string, slogValueFunc func(ctx context.Context) (slog.Value, bool)) Option {
+	return func(l *logger) {
+		if l.contextFuncs == nil {
+			l.contextFuncs = make(map[string]func(context.Context) (slog.Value, bool))
+		}
+		l.contextFuncs[slogAttrName] = slogValueFunc
 	}
 }


### PR DESCRIPTION
Context keys should be kept private to avoid collisions with other packages https://pkg.go.dev/context#Context.Value. `WithContextFunc` allows you to add `slog.Attr`s with `slog.Value`s from the `context.Context` in such situations. 

Implements https://github.com/orandin/slog-gorm/issues/24